### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Jacek Banaszczyk <jacek.banaszczyk@gmail.com>
 maintainer=Jacek Banaszczyk <jacek.banaszczyk@gmail.com>
 sentence=Some portable libraries for Arduino
 paragraph=Some portable libraries for Arduino
-category=Libraries
+category=Other
 url=https://github.com/jbanaszczyk/pms5003
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Libraries' in library ArduinoLibraries is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format